### PR TITLE
[Feat] Todo 컨테이너 UI & CSS

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,9 @@ const App: React.FC = () => {
     <Wrapper>
       <Header />
       <ContainerWrapper>
-        <TodoContainer title={status.ToDo} todoItems={mockData} />
-        <TodoContainer title={status.InProgress} todoItems={mockData} />
-        <TodoContainer title={status.Done} todoItems={mockData} />
+        <TodoContainer status={status.Todo} todoItems={mockData} />
+        <TodoContainer status={status.InProgress} todoItems={mockData} />
+        <TodoContainer status={status.Done} todoItems={mockData} />
       </ContainerWrapper>
     </Wrapper>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,33 @@
+import { status } from './utils/config';
+import mockData from './utils/data.json';
 import React from 'react';
 import styled from 'styled-components';
+import Header from 'components/common/Header';
 import TodoContainer from 'components/todos/TodoContainer';
 
 const App: React.FC = () => {
   return (
     <Wrapper>
-      <TodoContainer />
-      <TodoContainer />
-      <TodoContainer />
+      <Header />
+      <ContainerWrapper>
+        <TodoContainer title={status.ToDo} todoItems={mockData} />
+        <TodoContainer title={status.InProgress} todoItems={mockData} />
+        <TodoContainer title={status.Done} todoItems={mockData} />
+      </ContainerWrapper>
     </Wrapper>
   );
 };
 
-export default App;
-
 const Wrapper = styled.div`
+  width: 100%;
+`;
+
+const ContainerWrapper = styled.div`
+  width: 90%;
   display: flex;
   justify-content: center;
-  gap: 0 30px;
-  width: 1280px;
+  gap: 4px 30px;
   margin: 50px auto;
-  border: 1px solid #333;
 `;
+
+export default App;

--- a/src/components/common/CreateButton.tsx
+++ b/src/components/common/CreateButton.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const CreateButton: React.FC = () => {
+interface CreateButtonProps {
+  status: string;
+}
+
+const CreateButton: React.FC<CreateButtonProps> = ({ status }) => {
   return (
     <ButtonWrapper>
       <ButtonStyled>+</ButtonStyled>

--- a/src/components/common/CreateButton.tsx
+++ b/src/components/common/CreateButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const CreateButton: React.FC = () => {
+  return (
+    <ButtonWrapper>
+      <ButtonStyled>+</ButtonStyled>
+    </ButtonWrapper>
+  );
+};
+
+const ButtonWrapper = styled.div``;
+const ButtonStyled = styled.button``;
+
+export default CreateButton;

--- a/src/components/common/Filter.tsx
+++ b/src/components/common/Filter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Filter: React.FC = () => {
-  return <div></div>;
+  return <div>필터</div>;
 };
 
 export default Filter;

--- a/src/components/common/Form.tsx
+++ b/src/components/common/Form.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+import Input from './Input';
+
+const Form: React.FC = () => {
+  return (
+    <Wrapper>
+      <FormStyled>
+        <Input />
+        <h3>생성자 선택</h3>
+      </FormStyled>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  margin: 12px 0;
+  padding: 12px;
+  border: 1px solid green;
+`;
+
+const FormStyled = styled.form``;
+
+export default Form;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Header: React.FC = () => {
+  return (
+    <>
+      <HeaderWrapper>Todo List</HeaderWrapper>
+    </>
+  );
+};
+
+const HeaderWrapper = styled.h1`
+  padding: 12px;
+  font-size: 24px;
+  font-weight: 600;
+  border-bottom: 1px solid black;
+`;
+
+export default Header;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Input: React.FC = () => {
+  return (
+    <InputWrapper>
+      <InputStyled />
+    </InputWrapper>
+  );
+};
+
+const InputWrapper = styled.div``;
+const InputStyled = styled.input``;
+
+export default Input;

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const Input: React.FC = () => {
-  return <div></div>;
-};
-
-export default Input;

--- a/src/components/todos/TodoContainer.tsx
+++ b/src/components/todos/TodoContainer.tsx
@@ -1,19 +1,27 @@
+import { TodoTypes } from './TodoTypes';
 import React from 'react';
 import styled from 'styled-components';
 import TodoList from './TodoList';
 import TodoHeader from './TodoHeader';
+import Form from 'components/common/Form';
 
-const TodoContainer = () => {
+interface TodoContainerProps {
+  title: string;
+  todoItems: TodoTypes[];
+}
+
+const TodoContainer: React.FC<TodoContainerProps> = ({ title, todoItems }) => {
   return (
     <Wrapper>
-      <TodoHeader />
-      <TodoList />
+      <TodoHeader title={title} />
+      <Form />
+      <TodoList todoItems={todoItems} />
     </Wrapper>
   );
 };
 
-export default TodoContainer;
-
 const Wrapper = styled.div`
   width: 100%;
 `;
+
+export default TodoContainer;

--- a/src/components/todos/TodoContainer.tsx
+++ b/src/components/todos/TodoContainer.tsx
@@ -6,14 +6,14 @@ import TodoHeader from './TodoHeader';
 import Form from 'components/common/Form';
 
 interface TodoContainerProps {
-  title: string;
+  status: string;
   todoItems: TodoTypes[];
 }
 
-const TodoContainer: React.FC<TodoContainerProps> = ({ title, todoItems }) => {
+const TodoContainer: React.FC<TodoContainerProps> = ({ status, todoItems }) => {
   return (
     <Wrapper>
-      <TodoHeader title={title} />
+      <TodoHeader status={status} />
       <Form />
       <TodoList todoItems={todoItems} />
     </Wrapper>

--- a/src/components/todos/TodoHeader.tsx
+++ b/src/components/todos/TodoHeader.tsx
@@ -1,12 +1,31 @@
+import Button from 'components/common/CreateButton';
+import Filter from 'components/common/Filter';
 import React from 'react';
 import styled from 'styled-components';
 
-const TodoHeader = () => {
-  return <Wrapper>헤더</Wrapper>;
+interface TodoHeaderProps {
+  title: string;
+}
+
+const TodoHeader: React.FC<TodoHeaderProps> = ({ title }) => {
+  return (
+    <Wrapper>
+      <Title>{title}</Title>
+      <Button />
+      <Filter />
+    </Wrapper>
+  );
 };
 
-export default TodoHeader;
-
 const Wrapper = styled.div`
-  border: 1px solid green;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
+
+const Title = styled.h2`
+  flex: 1;
+`;
+
+export default TodoHeader;

--- a/src/components/todos/TodoHeader.tsx
+++ b/src/components/todos/TodoHeader.tsx
@@ -1,17 +1,17 @@
-import Button from 'components/common/CreateButton';
+import CreateButton from 'components/common/CreateButton';
 import Filter from 'components/common/Filter';
 import React from 'react';
 import styled from 'styled-components';
 
 interface TodoHeaderProps {
-  title: string;
+  status: string;
 }
 
-const TodoHeader: React.FC<TodoHeaderProps> = ({ title }) => {
+const TodoHeader: React.FC<TodoHeaderProps> = ({ status }) => {
   return (
     <Wrapper>
-      <Title>{title}</Title>
-      <Button />
+      <Title>{status}</Title>
+      <CreateButton status={status} />
       <Filter />
     </Wrapper>
   );

--- a/src/components/todos/TodoItem.tsx
+++ b/src/components/todos/TodoItem.tsx
@@ -1,22 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
-
-interface TodoProps {
-  id: number;
-  taskName: string;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
+import { Todo } from './TodoTypes';
+interface TodoItemProps {
+  item: Todo;
 }
 
-interface Item {
-  item: TodoProps;
-}
-
-const TodoItem: React.FC<Item> = ({ item }) => {
+const TodoItem: React.FC<TodoItemProps> = ({ item }) => {
   return (
     <Wrapper>
       <p>{item.taskName}</p>
+      <p>{item.creator}</p>
     </Wrapper>
   );
 };

--- a/src/components/todos/TodoItem.tsx
+++ b/src/components/todos/TodoItem.tsx
@@ -1,21 +1,31 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Todo } from './TodoTypes';
+import { TodoTypes } from './TodoTypes';
+
 interface TodoItemProps {
-  item: Todo;
+  todoItem: TodoTypes;
 }
 
-const TodoItem: React.FC<TodoItemProps> = ({ item }) => {
+const TodoItem: React.FC<TodoItemProps> = ({
+  todoItem: { taskName, creator, createdAt, updatedAt },
+}) => {
   return (
     <Wrapper>
-      <p>{item.taskName}</p>
-      <p>{item.creator}</p>
+      <TaskName>{taskName}</TaskName>
+      <p>{creator}</p>
+      <p>생성일 {createdAt}</p>
+      <p>수정일 {updatedAt}</p>
     </Wrapper>
   );
 };
 
-export default TodoItem;
-
 const Wrapper = styled.li`
   border: 1px solid blue;
 `;
+
+const TaskName = styled.h3`
+  font-size: 18px;
+  font-weight: 500;
+`;
+
+export default TodoItem;

--- a/src/components/todos/TodoList.tsx
+++ b/src/components/todos/TodoList.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import styled from 'styled-components';
 import TodoItem from './TodoItem';
 import todoItems from 'utils/data.json';
-import { Todo } from './TodoTypes';
+import { TodoTypes } from './TodoTypes';
 
-const TodoList: React.FC = () => {
+interface TodoListProps {
+  todoItems: TodoTypes[];
+}
+
+const TodoList: React.FC<TodoListProps> = () => {
   return (
     <Wrapper>
-      {todoItems.map((todo: Todo) => (
-        <TodoItem key={todo.id} item={todo} />
+      {todoItems.map((todoItem, i) => (
+        <TodoItem key={i} todoItem={todoItem} />
       ))}
     </Wrapper>
   );
@@ -16,6 +20,4 @@ const TodoList: React.FC = () => {
 
 export default TodoList;
 
-const Wrapper = styled.div`
-  border: 1px solid red;
-`;
+const Wrapper = styled.ul``;

--- a/src/components/todos/TodoList.tsx
+++ b/src/components/todos/TodoList.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import TodoItem from './TodoItem';
 import todoItems from 'utils/data.json';
-
-interface TodoProps {
-  id: number;
-  taskName: string;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import { Todo } from './TodoTypes';
 
 const TodoList: React.FC = () => {
   return (
     <Wrapper>
-      {todoItems.map((todo: TodoProps) => (
+      {todoItems.map((todo: Todo) => (
         <TodoItem key={todo.id} item={todo} />
       ))}
     </Wrapper>

--- a/src/components/todos/TodoTypes.ts
+++ b/src/components/todos/TodoTypes.ts
@@ -1,0 +1,8 @@
+export interface Todo {
+  id: number;
+  taskName: string;
+  status: string;
+  creator: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/components/todos/TodoTypes.ts
+++ b/src/components/todos/TodoTypes.ts
@@ -1,4 +1,4 @@
-export interface Todo {
+export interface TodoTypes {
   id: number;
   taskName: string;
   status: string;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -6,7 +6,9 @@ const GlobalStyle = createGlobalStyle`
   a {
     color:#333
   }
-
+  ul {
+    list-style:none;
+  }
 `;
 
 export default GlobalStyle;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,11 +1,11 @@
 interface Status {
-  ToDo: string;
+  Todo: string;
   InProgress: string;
   Done: string;
 }
 
 export const status: Status = {
-  ToDo: '할 일',
+  Todo: '할 일',
   InProgress: '진행 중',
   Done: '완료',
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,11 +1,11 @@
 interface Status {
-  FINISHED: string;
-  ONGOING: string;
-  NOT_STARTED: string;
+  ToDo: string;
+  InProgress: string;
+  Done: string;
 }
 
 export const status: Status = {
-  FINISHED: '완료',
-  ONGOING: '진행중',
-  NOT_STARTED: '시작안함',
+  ToDo: '할 일',
+  InProgress: '진행 중',
+  Done: '완료',
 };

--- a/src/utils/data.json
+++ b/src/utils/data.json
@@ -3,6 +3,7 @@
     "id": 1,
     "taskName": "자소서 쓰기",
     "status": "진행중",
+    "creator": "진수",
     "createdAt": "2021-02-03",
     "updatedAt": "2021-07-07"
   },
@@ -10,6 +11,7 @@
     "id": 2,
     "taskName": "자소서 쓰기",
     "status": "진행중",
+    "creator": "택훈",
     "createdAt": "2021-02-03",
     "updatedAt": "2021-07-06"
   },
@@ -17,6 +19,7 @@
     "id": 3,
     "taskName": "자소서 쓰기",
     "status": "시작안함",
+    "creator": "남주",
     "createdAt": "2021-02-03",
     "updatedAt": "2021-07-05"
   },
@@ -24,6 +27,7 @@
     "id": 4,
     "taskName": "자소서 쓰기",
     "status": "완료",
+    "creator": "삭",
     "createdAt": "2021-02-03",
     "updatedAt": "2021-07-04"
   }

--- a/src/utils/data.json
+++ b/src/utils/data.json
@@ -2,7 +2,7 @@
   {
     "id": 1,
     "taskName": "자소서 쓰기",
-    "status": "진행중",
+    "status": "진행 중",
     "creator": "진수",
     "createdAt": "2021-02-03",
     "updatedAt": "2021-07-07"
@@ -10,7 +10,7 @@
   {
     "id": 2,
     "taskName": "자소서 쓰기",
-    "status": "진행중",
+    "status": "진행 중",
     "creator": "택훈",
     "createdAt": "2021-02-03",
     "updatedAt": "2021-07-06"
@@ -18,7 +18,7 @@
   {
     "id": 3,
     "taskName": "자소서 쓰기",
-    "status": "시작안함",
+    "status": "할 일",
     "creator": "남주",
     "createdAt": "2021-02-03",
     "updatedAt": "2021-07-05"


### PR DESCRIPTION
## 수정사항
- Todo 컨테이너 구성
- 전체적인 리팩토링
- filter, form, input 추가
- status와 data.json 수정  // `Todo`, `InProgress`, `Done`

## 질문
`TodoContainer`를 `Todo`, `InProgress`, `Done` 세 개의 `status`를 `props`로 넘겨주어 재사용해주었는데

각 컨테이너의 **Filter**와 **Input Form**(open toggle)을 어떻게 관리하면 좋을까요?
새벽이라 그런지 방법이 잘 떠오르질 않네요..

`TodoContainer` x 3 이 아니라, 
`TodoContainer`, `InProgressContainer`, `DoneContainer` 각각 파일을 나눠서 관리하는게 나을까요?
