### PR TITLE
[Feat] 아이템 추가/삭제/변경 handler 세팅

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,6 +2,6 @@ module.exports = {
   semi: true,
   trailingComma: 'all',
   singleQuote: true,
-  printWidth: 80,
+  printWidth: 100,
   tabWidth: 2,
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,9 +9,9 @@ const App: React.FC = () => {
     <Wrapper>
       <Header />
       <ContainerWrapper>
-        <TodoContainer initialStatus={STATUS.Todo} />
-        <TodoContainer initialStatus={STATUS.InProgress} />
-        <TodoContainer initialStatus={STATUS.Done} />
+        <TodoContainer status={STATUS.Todo} />
+        <TodoContainer status={STATUS.InProgress} />
+        <TodoContainer status={STATUS.Done} />
       </ContainerWrapper>
     </Wrapper>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { status } from './utils/config';
+import { STATUS } from './utils/config';
 import mockData from './utils/data.json';
 import React from 'react';
 import styled from 'styled-components';
@@ -10,9 +10,9 @@ const App: React.FC = () => {
     <Wrapper>
       <Header />
       <ContainerWrapper>
-        <TodoContainer status={status.Todo} todoItems={mockData} />
-        <TodoContainer status={status.InProgress} todoItems={mockData} />
-        <TodoContainer status={status.Done} todoItems={mockData} />
+        <TodoContainer status={STATUS.Todo} todoItems={mockData} />
+        <TodoContainer status={STATUS.InProgress} todoItems={mockData} />
+        <TodoContainer status={STATUS.Done} todoItems={mockData} />
       </ContainerWrapper>
     </Wrapper>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { STATUS } from './utils/config';
-import mockData from './utils/data.json';
 import React from 'react';
 import styled from 'styled-components';
 import Header from 'components/common/Header';
@@ -10,9 +9,9 @@ const App: React.FC = () => {
     <Wrapper>
       <Header />
       <ContainerWrapper>
-        <TodoContainer status={STATUS.Todo} todoItems={mockData} />
-        <TodoContainer status={STATUS.InProgress} todoItems={mockData} />
-        <TodoContainer status={STATUS.Done} todoItems={mockData} />
+        <TodoContainer initialStatus={STATUS.Todo} />
+        <TodoContainer initialStatus={STATUS.InProgress} />
+        <TodoContainer initialStatus={STATUS.Done} />
       </ContainerWrapper>
     </Wrapper>
   );

--- a/src/components/common/CreateButton.tsx
+++ b/src/components/common/CreateButton.tsx
@@ -3,12 +3,13 @@ import styled from 'styled-components';
 
 interface CreateButtonProps {
   status: string;
+  handleFormOpen: (status: string) => void;
 }
 
-const CreateButton: React.FC<CreateButtonProps> = ({ status }) => {
+const CreateButton: React.FC<CreateButtonProps> = ({ status, handleFormOpen }) => {
   return (
     <ButtonWrapper>
-      <ButtonStyled>+</ButtonStyled>
+      <ButtonStyled onClick={() => handleFormOpen(status)}>+</ButtonStyled>
     </ButtonWrapper>
   );
 };

--- a/src/components/common/Form.tsx
+++ b/src/components/common/Form.tsx
@@ -2,10 +2,24 @@ import React from 'react';
 import styled from 'styled-components';
 import Input from './Input';
 
-const Form: React.FC = () => {
+interface FormProps {
+  clickedForm: string;
+  handleTodoCreate: () => void;
+}
+
+const Form: React.FC<FormProps> = ({ clickedForm, handleTodoCreate }) => {
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log(clickedForm);
+  };
+
+  const onCreate = () => {
+    // handleTodoCreate();
+  };
+
   return (
     <Wrapper>
-      <FormStyled>
+      <FormStyled onSubmit={onSubmit}>
         <Input />
         <h3>생성자 선택</h3>
       </FormStyled>

--- a/src/components/todos/TodoContainer.tsx
+++ b/src/components/todos/TodoContainer.tsx
@@ -7,24 +7,19 @@ import Form from 'components/common/Form';
 import mockData from '../../utils/data.json';
 
 interface TodoContainerProps {
-  initialStatus: string;
+  status: string;
 }
 
-const TodoContainer: React.FC<TodoContainerProps> = ({ initialStatus }) => {
-  const [todoItems, setTodoItems] = useState<TodoTypes[]>(mockData);
-  const [clickedForm, setClickedForm] = useState<string>(); // form toggle용
-  const [status, setStatus] = useState<string>(initialStatus);
+const TodoContainer: React.FC<TodoContainerProps> = ({ status }) => {
+  const [todoItems, setTodoItems] = useState<TodoTypes[]>(currentTodos(status, mockData));
+  const [clickedForm, setClickedForm] = useState<string>(); // 폼이 클릭된 컨테이너 -> form toggle용
 
-  // 입력폼 열고 닫는 함수
-  const handleFormOpen = (clickedContainer: string) => {
-    setClickedForm(clickedForm ? '' : clickedContainer);
-  };
+  const handleFormOpen = (target: string) => setClickedForm(clickedForm ? '' : target); // 입력폼 열고 닫는 함수
+  const handleTodoCreate = () => console.log(status); // 입력폼 submit 후, todoItem 생성하는 함수 (미완)
+  const handleTodoDelete = () => console.log(status); // x 버튼(만들어야함)누르면, todoItem 삭제하는 함수 (미완)
+  const handleTodoUpdate = () => console.log(status); // 드래그앤 드랍 등 todoItem 변경하는 함수 (미완)
 
-  const handleTodoCreate = () => console.log(status); // 입력폼 submit 후, todoItem 생성하는 함수
-  const handleTodoDelete = () => console.log(status); // x 버튼(만들어야함)누르면, todoItem 삭제하는 함수
-  const handleTodoUpdate = () => console.log(status); // 드래그앤 드랍 등 todoItem 변경하는 함수
-
-  // 클릭된 form과 현재 컨테이너의 status와 일치하는 컨테이너의 Form 오픈
+  // 클릭된 form과 현재 컨테이너의 status와 일치하는 컨테이너의 Form 오픈한다
   return (
     <Wrapper>
       <TodoHeader status={status} handleFormOpen={handleFormOpen} />
@@ -40,6 +35,9 @@ const TodoContainer: React.FC<TodoContainerProps> = ({ initialStatus }) => {
     </Wrapper>
   );
 };
+
+const currentTodos = (status: string, items: TodoTypes[]) =>
+  items.filter((item) => item.status === status);
 
 const Wrapper = styled.div`
   width: 100%;

--- a/src/components/todos/TodoContainer.tsx
+++ b/src/components/todos/TodoContainer.tsx
@@ -1,5 +1,5 @@
 import { TodoTypes } from './TodoTypes';
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import TodoList from './TodoList';
 import TodoHeader from './TodoHeader';
@@ -11,10 +11,16 @@ interface TodoContainerProps {
 }
 
 const TodoContainer: React.FC<TodoContainerProps> = ({ status, todoItems }) => {
+  const [clickedContainer, setClickedContainer] = useState<string>();
+
+  const handleFormOpen = (target: string) => {
+    setClickedContainer(clickedContainer ? '' : target);
+  };
+
   return (
     <Wrapper>
-      <TodoHeader status={status} />
-      <Form />
+      <TodoHeader status={status} handleFormOpen={handleFormOpen} />
+      {clickedContainer && status && <Form />}
       <TodoList todoItems={todoItems} />
     </Wrapper>
   );

--- a/src/components/todos/TodoContainer.tsx
+++ b/src/components/todos/TodoContainer.tsx
@@ -1,27 +1,42 @@
 import { TodoTypes } from './TodoTypes';
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import TodoList from './TodoList';
 import TodoHeader from './TodoHeader';
 import Form from 'components/common/Form';
+import mockData from '../../utils/data.json';
 
 interface TodoContainerProps {
-  status: string;
-  todoItems: TodoTypes[];
+  initialStatus: string;
 }
 
-const TodoContainer: React.FC<TodoContainerProps> = ({ status, todoItems }) => {
-  const [clickedContainer, setClickedContainer] = useState<string>();
+const TodoContainer: React.FC<TodoContainerProps> = ({ initialStatus }) => {
+  const [todoItems, setTodoItems] = useState<TodoTypes[]>(mockData);
+  const [clickedForm, setClickedForm] = useState<string>(); // form toggle용
+  const [status, setStatus] = useState<string>(initialStatus);
 
-  const handleFormOpen = (target: string) => {
-    setClickedContainer(clickedContainer ? '' : target);
+  // 입력폼 열고 닫는 함수
+  const handleFormOpen = (clickedContainer: string) => {
+    setClickedForm(clickedForm ? '' : clickedContainer);
   };
 
+  const handleTodoCreate = () => console.log(status); // 입력폼 submit 후, todoItem 생성하는 함수
+  const handleTodoDelete = () => console.log(status); // x 버튼(만들어야함)누르면, todoItem 삭제하는 함수
+  const handleTodoUpdate = () => console.log(status); // 드래그앤 드랍 등 todoItem 변경하는 함수
+
+  // 클릭된 form과 현재 컨테이너의 status와 일치하는 컨테이너의 Form 오픈
   return (
     <Wrapper>
       <TodoHeader status={status} handleFormOpen={handleFormOpen} />
-      {clickedContainer && status && <Form />}
-      <TodoList todoItems={todoItems} />
+      {clickedForm && status && (
+        <Form clickedForm={clickedForm} handleTodoCreate={handleTodoCreate} />
+      )}
+      <TodoList
+        status={status}
+        todoItems={todoItems}
+        handleTodoDelete={handleTodoDelete}
+        handleTodoUpdate={handleTodoUpdate}
+      />
     </Wrapper>
   );
 };

--- a/src/components/todos/TodoHeader.tsx
+++ b/src/components/todos/TodoHeader.tsx
@@ -5,13 +5,14 @@ import styled from 'styled-components';
 
 interface TodoHeaderProps {
   status: string;
+  handleFormOpen: (status: string) => void;
 }
 
-const TodoHeader: React.FC<TodoHeaderProps> = ({ status }) => {
+const TodoHeader: React.FC<TodoHeaderProps> = ({ status, handleFormOpen }) => {
   return (
     <Wrapper>
       <Title>{status}</Title>
-      <CreateButton status={status} />
+      <CreateButton status={status} handleFormOpen={handleFormOpen} />
       <Filter />
     </Wrapper>
   );

--- a/src/components/todos/TodoItem.tsx
+++ b/src/components/todos/TodoItem.tsx
@@ -3,14 +3,24 @@ import styled from 'styled-components';
 import { TodoTypes } from './TodoTypes';
 
 interface TodoItemProps {
+  status: string;
   todoItem: TodoTypes;
+  handleTodoUpdate: () => void;
+  handleTodoDelete: () => void;
 }
 
 const TodoItem: React.FC<TodoItemProps> = ({
   todoItem: { taskName, creator, createdAt, updatedAt },
+  status,
+  handleTodoUpdate,
+  handleTodoDelete,
 }) => {
   return (
-    <Wrapper>
+    <Wrapper
+      onClick={() => {
+        console.log(`"${status}" 컨테이너`);
+      }}
+    >
       <TaskName>{taskName}</TaskName>
       <p>{creator}</p>
       <p>생성일 {createdAt}</p>

--- a/src/components/todos/TodoList.tsx
+++ b/src/components/todos/TodoList.tsx
@@ -1,18 +1,31 @@
 import React from 'react';
 import styled from 'styled-components';
 import TodoItem from './TodoItem';
-import todoItems from 'utils/data.json';
 import { TodoTypes } from './TodoTypes';
 
 interface TodoListProps {
+  status: string;
   todoItems: TodoTypes[];
+  handleTodoUpdate: () => void;
+  handleTodoDelete: () => void;
 }
 
-const TodoList: React.FC<TodoListProps> = () => {
+const TodoList: React.FC<TodoListProps> = ({
+  status,
+  todoItems,
+  handleTodoDelete,
+  handleTodoUpdate,
+}) => {
   return (
     <Wrapper>
       {todoItems.map((todoItem, i) => (
-        <TodoItem key={i} todoItem={todoItem} />
+        <TodoItem
+          key={i}
+          status={status}
+          todoItem={todoItem}
+          handleTodoUpdate={handleTodoUpdate}
+          handleTodoDelete={handleTodoDelete}
+        />
       ))}
     </Wrapper>
   );

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,7 +4,7 @@ interface Status {
   Done: string;
 }
 
-export const status: Status = {
+export const STATUS: Status = {
   Todo: '할 일',
   InProgress: '진행 중',
   Done: '완료',


### PR DESCRIPTION
## 구현사항
- 아이템 삭제/추가/업데이트 관련 handler를 관련 컴포넌트에 세팅
- 입력폼 토글(on/off)
- 각 컨테이너의 status에 맞게 item 필터링

## 변경사항
- `prettierrc` 최대 줄 길이 80 -> 100 : _너무 짧은 것 같아서 ㅠ_
- `config`안의 고정 변수인 `status`를 `STATUS`로 바꿨습니다. 